### PR TITLE
fix: auth not working behind proxy

### DIFF
--- a/src/main/java/dev/morazzer/cookies/backend/controllers/AuthController.java
+++ b/src/main/java/dev/morazzer/cookies/backend/controllers/AuthController.java
@@ -24,7 +24,13 @@ public class AuthController {
     @PostMapping({"login", "auth"})
     public AuthResponse auth(@RequestBody AuthRequest authRequest, HttpServletRequest req, @RequestHeader("User-Agent") String userAgent) {
         try {
-            return authService.createToken(userAgent, authRequest, req.getRemoteAddr());
+            final String ip;
+            if (req.getHeader("X-Forwarded-For") != null) {
+                ip = req.getHeader("X-Forwarded-For");
+            } else {
+                ip = req.getRemoteAddr();
+            }
+            return authService.createToken(userAgent, authRequest, ip);
         } catch (InvalidCredentialsException ignored) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Couldn't authorize");
         } catch (Exception e) {

--- a/src/main/java/dev/morazzer/cookies/backend/services/MojangAuthService.java
+++ b/src/main/java/dev/morazzer/cookies/backend/services/MojangAuthService.java
@@ -19,11 +19,6 @@ public class MojangAuthService {
     public Optional<MinecraftUser> isAuthenticated(String sharedSecret, String username, String ip) {
         String request = BASE_URL + "?username=%s&serverId=%s&ip=%s".formatted(username, sharedSecret, ip);
         try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-        try {
             final URLConnection connection = URI.create(request).toURL().openConnection();
             connection.connect();
             connection.setReadTimeout(100);

--- a/src/main/java/dev/morazzer/cookies/backend/ws/PlayerConnection.java
+++ b/src/main/java/dev/morazzer/cookies/backend/ws/PlayerConnection.java
@@ -1,6 +1,5 @@
 package dev.morazzer.cookies.backend.ws;
 
-import dev.morazzer.cookies.backend.BackendApplication;
 import dev.morazzer.cookies.backend.services.BackendRedisService;
 import dev.morazzer.cookies.backend.utils.redis.PlayerKey;
 import dev.morazzer.cookies.entities.websocket.Packet;
@@ -97,11 +96,10 @@ public final class PlayerConnection {
 
     public void setDungeonSession(String formatted) {
         final String dungeonSession = "dungeons.session." + formatted;
-        System.out.println("Setting dungeon session: " + dungeonSession);
         this.scopes.add(dungeonSession);
     }
 
-    public void removeScope(String scope) {;
+    public void removeScope(String scope) {
         this.scopes.remove(scope);
     }
 


### PR DESCRIPTION
Server will now by default use the `X-Forwarded-For` header if it is present. If the header isn't found it will fall back to the connection ip.